### PR TITLE
EventGuestView Spotify Token

### DIFF
--- a/src/components/EventGuestView.js
+++ b/src/components/EventGuestView.js
@@ -95,25 +95,21 @@ const EventGuestView = props => {
     // If a guest comes to this page without logging in as a DJ first,
     // they need to get a Spotify access token to see the songs' components.
     // This will get the token and put it in localStorage.
-    if (!localStorage.getItem('spotifyAccessToken')) {
-      // Getting client id, secret, and grant type into correct format
-      const data = new URLSearchParams({
-        client_id: process.env.REACT_APP_SPOTIFY_CLIENT_ID,
-        grant_type: 'client_credentials'
+
+    // Getting client id, secret, and grant type into correct format
+    const data = new URLSearchParams({
+      client_id: process.env.REACT_APP_SPOTIFY_CLIENT_ID,
+      grant_type: 'client_credentials'
+    });
+    // Getting an access token for the spotify API
+    axiosWithAuthSpotify()
+      .post('/api/token', data)
+      .then(response => {
+        localStorage.setItem('spotifyAccessToken', response.data.access_token);
+      })
+      .catch(err => {
+        // handle error
       });
-      // Getting an access token for the spotify API
-      axiosWithAuthSpotify()
-        .post('/api/token', data)
-        .then(response => {
-          localStorage.setItem(
-            'spotifyAccessToken',
-            response.data.access_token
-          );
-        })
-        .catch(err => {
-          // handle error
-        });
-    }
   }, []);
 
   // Adds nav if mobile display


### PR DESCRIPTION
# Description

Fixes bug where stale Spotify tokens were not replaced in EventGuestView, so playlists weren't being displayed the day after a user initially used the app. Now a new token is retrieved and put into localStorage whenever a EventGuestView page is rendered.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?

- Tests still run and pass.
- Before this change was pushed to our staging deployment, my phone could no longer display playlists in any EventGuestView pages. (The Spotify token stored on my phone must have expired). After pushing this change to the staging deployment, my phone now displays the playlists.

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
